### PR TITLE
Issue #12 change connection datetime to date

### DIFF
--- a/kitcatapp/admin.py
+++ b/kitcatapp/admin.py
@@ -17,8 +17,9 @@ class ContactAdmin(admin.ModelAdmin):
 
 class ConnectionAdmin(admin.ModelAdmin):
     fieldsets = [
-        (None, {'fields': [('contact', 'is_complete'), 'notes']}),
+        (None, {'fields': [('contact', 'due_date', 'is_complete'), 'notes']}),
     ]
+    list_display = ('contact', 'status', 'due_date')
 
 admin.site.register(Contact, ContactAdmin)
 admin.site.register(Connection, ConnectionAdmin)

--- a/kitcatapp/admin.py
+++ b/kitcatapp/admin.py
@@ -17,9 +17,8 @@ class ContactAdmin(admin.ModelAdmin):
 
 class ConnectionAdmin(admin.ModelAdmin):
     fieldsets = [
-        (None, {'fields': [('contact', 'due_date', 'is_complete'), 'notes']}),
+        (None, {'fields': [('contact', 'is_complete'), 'notes']}),
     ]
-    list_display = ('contact', 'status', 'due_date')
 
 admin.site.register(Contact, ContactAdmin)
 admin.site.register(Connection, ConnectionAdmin)

--- a/kitcatapp/migrations/0002_remove_connection_due_date.py
+++ b/kitcatapp/migrations/0002_remove_connection_due_date.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kitcatapp', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='connection',
+            name='due_date',
+        ),
+    ]

--- a/kitcatapp/migrations/0003_connection_due_date.py
+++ b/kitcatapp/migrations/0003_connection_due_date.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kitcatapp', '0002_remove_connection_due_date'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='connection',
+            name='due_date',
+            field=models.DateField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/kitcatapp/models.py
+++ b/kitcatapp/models.py
@@ -42,29 +42,4 @@ class Connection(models.Model):
 
     contact = models.ForeignKey(Contact)
     is_complete = models.BooleanField(default=False)
-    due_date = models.DateTimeField(default=0)
     notes = models.TextField(blank=True)
-
-    def _get_status(self):
-        "Returns the status of the connection based on today's date."
-        SCHEDULED = 'Scheduled'
-        DUE       = 'Due'
-        OVERDUE   = 'Overdue'
-        COMPLETE  = 'Complete'
-
-        if self.is_complete is True:
-            return COMPLETE
-
-        today = datetime.today()
-        delta = (self.due_date.date() - datetime.today().date()).days
-
-        if delta < 0:
-            return SCHEDULED
-        elif delta is 0:
-            return DUE
-        else:
-            return OVERDUE
-    status = property(_get_status)
-
-    def __str__(self):
-        return '%s %s %s' % (self.contact.first_name, self.contact.last_name, self.due_date.date())

--- a/kitcatapp/models.py
+++ b/kitcatapp/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from datetime import datetime
+from django.utils import timezone
 
 class Contact(models.Model):
     DAILY      = '1'
@@ -42,4 +43,29 @@ class Connection(models.Model):
 
     contact = models.ForeignKey(Contact)
     is_complete = models.BooleanField(default=False)
+    due_date = models.DateField(default=timezone.now)
     notes = models.TextField(blank=True)
+
+    def _get_status(self):
+        "Returns the status of the connection based on today's date."
+        SCHEDULED = 'Scheduled'
+        DUE       = 'Due'
+        OVERDUE   = 'Overdue'
+        COMPLETE  = 'Complete'
+
+        if self.is_complete is True:
+            return COMPLETE
+
+        today = datetime.today()
+        delta = (self.due_date - datetime.today().date()).days
+
+        if delta > 0:
+            return SCHEDULED
+        elif delta is 0:
+            return DUE
+        else:
+            return OVERDUE
+    status = property(_get_status)
+
+    def __str__(self):
+        return '%s %s %s' % (self.contact.first_name, self.contact.last_name, self.due_date)


### PR DESCRIPTION
### What
- To make date comparisons easier, use a DateField instead of a DateTimeField for connection.due_date
- Migration to remove previous field
- Migration to add new due_date field as DateField
- Also fixed bug where status was reversed 
### Test
- Run `python manage.py migrate --list` to check db status and migrations
- Migrate with `python manage.py migrate`
- Check functionality in admin pages
