### PR TITLE
Issue 8 add sms reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ ALTER USER kitcat_user CREATEDB;
 export KITCAT_DB_NAME=kitcat_db
 export KITCAT_DB_USER=kitcat_user
 export KITCAT_DB_PASSWORD=<password>
+
+export KITCAT_TWILIO_SID=<sid>
+export KITCAT_TWILIO_AUTH=<auth token>
+export KITCAT_TWILIO_TO_PHONE=<Twilio-registered test phone number>
+export KITCAT_TWILIO_FROM_PHONE=<Twilio-registered test phone number>
+
+export TEST_TWILIO_SID=<test sid>
+export TEST_TWILIO_AUTH=<test auth token>
+export TEST_TWILIO_TO_PHONE=<Twilio-registered test phone number>
+export TEST_TWILIO_FROM_PHONE=+15005550006
 ```
 
 #### Initializing Dev Environment
@@ -62,8 +72,5 @@ heroku run python manage.py migrate kitcatapp # Apply migrations
 
 ## Custom Commands
 
-#### Get connections due on or before today
-* Run `python manage.py get_reminders`
-
-#### Get connectinons due on or before test date
-* Run `python manage.py get_reminders --test`
+#### Get connections due on or before date (default to today)
+* Run `python manage.py get_reminders -y 2016 -d 30 -m 03`

--- a/kitcatapp/management/commands/get_reminders.py
+++ b/kitcatapp/management/commands/get_reminders.py
@@ -2,6 +2,8 @@ from django.core.management.base import BaseCommand, CommandError
 from kitcatapp.models import Contact, Connection
 from django.utils import timezone
 import datetime
+import os
+from kitcatapp.src._twilio import Twilio
 
 class Command(BaseCommand):
     help = 'Finds due and overdue connections'
@@ -13,24 +15,40 @@ class Command(BaseCommand):
             default=False,
             help='Run command in test environment')
 
+    def _send_sms_reminder(self, reminder_text):
+        account_sid = os.environ.get('KITCAT_TWILIO_SID')
+        auth_token = os.environ.get('KITCAT_TWILIO_AUTH')
+        from_phone = os.environ.get('KITCAT_TWILIO_FROM_PHONE')
+        twilio = Twilio(account_sid, auth_token, from_phone)
+
+        to_phone = os.environ.get('KITCAT_TWILIO_TO_PHONE')
+        twilio.send_sms(to_phone, reminder_text)
+
     def _get_due_connections(self, due_date):
         due_connections = Connection.objects.filter(due_date=due_date)
+        message = ''
         for connection in due_connections:
-            self.stdout.write("%s %s" % (connection, connection.is_complete))
+            message += "Call %s %s!\n" % (connection.contact.first_name,
+                connection.contact.last_name)
+        return message
 
     def _get_overdue_connections(self, due_date):
         yesterday = due_date - datetime.timedelta(days=1)
         start_date = datetime.date(1000, 1, 1)
         overdue_connections = Connection.objects.filter(due_date__range=(
             start_date, yesterday)).order_by('-due_date')
+        message = ''
         for connection in overdue_connections:
-            self.stdout.write("%s %s" % (connection, connection.is_complete))
+            message += "Really, call %s %s!\n" % (connection.contact.first_name,
+                connection.contact.last_name)
+        return message
 
     def handle(self, *args, **options):
         if options['test']:
-            due_date = datetime.date(2016,03,29)
+            due_date = datetime.date(2016,03,19)
         else:
             due_date = datetime.datetime.now().date()
 
-        self._get_due_connections(due_date)
-        self._get_overdue_connections(due_date)
+        due_message = self._get_due_connections(due_date)
+        overdue_message = self._get_overdue_connections(due_date)
+        self._send_sms_reminder(due_message + overdue_message)

--- a/kitcatapp/management/commands/get_reminders.py
+++ b/kitcatapp/management/commands/get_reminders.py
@@ -8,13 +8,6 @@ from kitcatapp.src._twilio import Twilio
 class Command(BaseCommand):
     help = 'Finds due and overdue connections'
 
-    def add_arguments(self, parser):
-        parser.add_argument('--test',
-            action='store_true',
-            dest='test',
-            default=False,
-            help='Run command in test environment')
-
     def _send_sms_reminder(self, reminder_text):
         account_sid = os.environ.get('KITCAT_TWILIO_SID')
         auth_token = os.environ.get('KITCAT_TWILIO_AUTH')

--- a/kitcatapp/management/commands/get_reminders.py
+++ b/kitcatapp/management/commands/get_reminders.py
@@ -43,12 +43,24 @@ class Command(BaseCommand):
                 connection.contact.last_name)
         return message
 
+    def add_arguments(self, parser):
+        parser.add_argument('-y', '--year', type=int, choices=range(2015, 2025))
+        parser.add_argument('-m', '--month', type=int, choices=range(1, 12))
+        parser.add_argument('-d', '--day', type=int, choices=range(1, 31))
+
     def handle(self, *args, **options):
-        if options['test']:
-            due_date = datetime.date(2016,03,19)
-        else:
+        try:
+            year = options['year']
+            month = options['month']
+            day = options['day']
+            due_date = datetime.date(year,month,day)
+        except ValueError:
+            print('No valid date option.')
             due_date = datetime.datetime.now().date()
 
+        print('Fetching reminders for %s' % str(due_date))
         due_message = self._get_due_connections(due_date)
         overdue_message = self._get_overdue_connections(due_date)
-        self._send_sms_reminder(due_message + overdue_message)
+        message = due_message + overdue_message
+        if message is not '':
+            self._send_sms_reminder(due_message + overdue_message)

--- a/kitcatapp/management/commands/get_reminders.py
+++ b/kitcatapp/management/commands/get_reminders.py
@@ -37,23 +37,26 @@ class Command(BaseCommand):
         return message
 
     def add_arguments(self, parser):
-        parser.add_argument('-y', '--year', type=int, choices=range(2015, 2025))
-        parser.add_argument('-m', '--month', type=int, choices=range(1, 12))
-        parser.add_argument('-d', '--day', type=int, choices=range(1, 31))
+        today = datetime.datetime.now().date()
+        parser.add_argument('-y', '--year', default=today.year, type=int, choices=range(2015, 2025))
+        parser.add_argument('-m', '--month', default=today.month, type=int, choices=range(1, 12))
+        parser.add_argument('-d', '--day', default=today.day, type=int, choices=range(1, 31))
 
     def handle(self, *args, **options):
         try:
             year = options['year']
             month = options['month']
             day = options['day']
+
             due_date = datetime.date(year,month,day)
+
+            due_message = self._get_due_connections(due_date)
+            overdue_message = self._get_overdue_connections(due_date)
+            message = due_message + overdue_message
+
+            if message:
+                self._send_sms_reminder(due_message + overdue_message)
+
         except ValueError:
             print('No valid date option.')
-            due_date = datetime.datetime.now().date()
-
-        print('Fetching reminders for %s' % str(due_date))
-        due_message = self._get_due_connections(due_date)
-        overdue_message = self._get_overdue_connections(due_date)
-        message = due_message + overdue_message
-        if message is not '':
-            self._send_sms_reminder(due_message + overdue_message)
+            raise

--- a/kitcatapp/src/_twilio.py
+++ b/kitcatapp/src/_twilio.py
@@ -1,0 +1,12 @@
+from twilio.rest import TwilioRestClient
+
+class Twilio(object):
+
+    def __init__(self, account_sid, auth_token, from_phone):
+        self.client = TwilioRestClient(account_sid, auth_token)
+        self.from_phone = from_phone
+
+    def send_sms(self, to_phone, message):
+        sms = self.client.messages.create(to=to_phone, from_=self.from_phone,
+            body=message)
+        return sms

--- a/kitcatapp/tests.py
+++ b/kitcatapp/tests.py
@@ -91,13 +91,23 @@ class CommandTest(TestCase):
         self.env.set('KITCAT_TWILIO_FROM_PHONE', '+15005550006')
 
     fixtures = ['contacts', 'connections']
-    def test_sms_reminder(self):
+    def test_sms_reminder_with_date_including_reminders(self):
         with mock.patch.object(Twilio, 'send_sms'):
             call_command('get_reminders', '-y 2016', '-d 19', '-m 03')
             self.assertTrue(Twilio.send_sms.called, "Failed to send SMS.")
             to_phone = '+17036257313'
             reminder_text = 'Call Amy Schumer!\nReally, call Tina Fey!\n'
             Twilio.send_sms.assert_called_once_with(to_phone, reminder_text)
+
+    def test_sms_reminder_with_date_without_reminders(self):
+        with mock.patch.object(Twilio, 'send_sms'):
+            call_command('get_reminders', '-y 2015', '-d 19', '-m 03')
+            self.assertFalse(Twilio.send_sms.called, "Tried to send empty SMS.")
+
+    def test_sms_reminder_without_date(self):
+        with mock.patch.object(Twilio, 'send_sms'):
+            call_command('get_reminders')
+            self.assertTrue(Twilio.send_sms.called, "Failed to send SMS.")
 
 # Src
 class TwilioTest(TestCase):

--- a/kitcatapp/tests.py
+++ b/kitcatapp/tests.py
@@ -3,7 +3,6 @@ from kitcatapp.models import Contact, Connection
 from django.utils import timezone
 import datetime
 from django.core.management import call_command
-from django.utils.six import StringIO
 from test.test_support import EnvironmentVarGuard
 import os
 from kitcatapp.src._twilio import Twilio
@@ -94,9 +93,7 @@ class CommandTest(TestCase):
     fixtures = ['contacts', 'connections']
     def test_sms_reminder(self):
         with mock.patch.object(Twilio, 'send_sms'):
-            out = StringIO()
-            call_command('get_reminders', '--test', stdout=out)
-            # --test flag sets test date to 2016-03-29
+            call_command('get_reminders', '-y 2016', '-d 19', '-m 03')
             self.assertTrue(Twilio.send_sms.called, "Failed to send SMS.")
             to_phone = '+17036257313'
             reminder_text = 'Call Amy Schumer!\nReally, call Tina Fey!\n'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,9 @@ Django==1.8
 coverage==4.0.3
 dj-database-url==0.4.0
 gunicorn==19.4.5
+httplib2==0.9.2
 psycopg2==2.6.1
+pytz==2016.3
+six==1.10.0
+twilio==5.4.0
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 Django==1.8
 coverage==4.0.3
 dj-database-url==0.4.0
+funcsigs==0.4
 gunicorn==19.4.5
 httplib2==0.9.2
+mock==1.3.0
+pbr==1.8.1
 psycopg2==2.6.1
 pytz==2016.3
 six==1.10.0


### PR DESCRIPTION
### What
- Add Twilio integration to custom command that fetches reminders
  - Twilio module wraps Twilio calls
- Send SMS message with simple reminder  for due and overdue connections
- Added tests with endpoint mocked
### Test
- Be sure to set environment variables, run tests
- Phone numbers must be registered with Twilio
- Test with no due/overdue connects, with either, and both
- Test before, on, and after key dates
### Deploy
- Update Heroku Scheduler command when deploying
